### PR TITLE
Helm Chart

### DIFF
--- a/deploy/helm/rclone-csi/.helmignore
+++ b/deploy/helm/rclone-csi/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/helm/rclone-csi/Chart.yaml
+++ b/deploy/helm/rclone-csi/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.2.4"
+description: A Helm chart to deploy the RClone-CSI Plugin
+name: rclone-csi
+version: 0.1.0

--- a/deploy/helm/rclone-csi/templates/_helpers.tpl
+++ b/deploy/helm/rclone-csi/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rclone-csi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rclone-csi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rclone-csi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/helm/rclone-csi/templates/csi-controller-rbac.yaml
+++ b/deploy/helm/rclone-csi/templates/csi-controller-rbac.yaml
@@ -1,0 +1,91 @@
+# This YAML file contains RBAC API objects that are necessary to run external
+# CSI attacher for rclone adapter
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-rclone
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-controller-rclone
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-attacher-role-rclone
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-rclone
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-controller-rclone
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cluster-driver-registrar-role
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-cluster-driver-registrar-binding
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-rclone
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-cluster-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/rclone-csi/templates/csi-controller-rclone.yaml
+++ b/deploy/helm/rclone-csi/templates/csi-controller-rclone.yaml
@@ -1,0 +1,73 @@
+# This YAML file contains attacher & csi driver API objects that are necessary
+# to run external CSI attacher for rclone
+
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-controller-rclone
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  serviceName: "csi-controller-rclone"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller-rclone
+  template:
+    metadata:
+      labels:
+        app: csi-controller-rclone
+        app.kubernetes.io/name: {{ include "rclone-csi.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: csi-controller-rclone
+      containers:
+        - name: csi-attacher
+          image: {{ .Values.csiAttacher.image }}
+          args:
+            {{- range $arg := .Values.csiAttacher.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-cluster-driver-registrar
+          image: {{ .Values.csiClusterRegistrar.image }}
+          args:
+            {{- range $arg := .Values.csiClusterRegistrar.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: rclone
+          image: wunderio/csi-rclone:v1.2.3
+          args:
+            {{- range $arg := .Values.csiPlugin.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /plugin
+      volumes:
+        - name: socket-dir
+          emptyDir:

--- a/deploy/helm/rclone-csi/templates/csi-nodeplugin-rbac.yaml
+++ b/deploy/helm/rclone-csi/templates/csi-nodeplugin-rbac.yaml
@@ -1,0 +1,55 @@
+# This YAML defines all API objects to create RBAC roles for CSI node plugin
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nodeplugin-rclone
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-rclone
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets","secret"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nodeplugin-rclone
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: csi-nodeplugin-rclone
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-nodeplugin-rclone
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/rclone-csi/templates/csi-nodeplugin-rclone.yaml
+++ b/deploy/helm/rclone-csi/templates/csi-nodeplugin-rclone.yaml
@@ -1,0 +1,89 @@
+# This YAML file contains driver-registrar & csi driver nodeplugin API objects
+# that are necessary to run CSI nodeplugin for rclone
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nodeplugin-rclone
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" . }}
+    helm.sh/chart: {{ include "rclone-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: csi-nodeplugin-rclone
+  template:
+    metadata:
+      labels:
+        app: csi-nodeplugin-rclone
+        app.kubernetes.io/name: {{ include "rclone-csi.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: csi-nodeplugin-rclone
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: node-driver-registrar
+          image: {{ .Values.csiNodeRegistrar.image }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi-rclone /registration/csi-rclone-reg.sock"]
+          args:
+            {{- range $arg := .Values.csiNodeRegistrar.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: rclone
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{ .Values.csiPlugin.image }}
+          args:
+            {{- range $arg := .Values.csiPlugin.args }}
+            - {{ $arg | quote -}}
+            {{- end }}
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix://plugin/csi.sock
+          imagePullPolicy: "Always"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "mount -t fuse.rclone | while read -r mount; do umount $(echo $mount | awk '{print $3}') ; done"]
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+      volumes:
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.pluginDirectory }}
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: DirectoryOrCreate

--- a/deploy/helm/rclone-csi/templates/csi-rclone-storageclass.yaml
+++ b/deploy/helm/rclone-csi/templates/csi-rclone-storageclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClassName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "rclone-csi.name" $ }}
+    helm.sh/chart: {{ include "rclone-csi.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app: csi-nodeplugin-rclone
+provisioner: csi-nodeplugin-rclone

--- a/deploy/helm/rclone-csi/templates/rclone-secret.yaml
+++ b/deploy/helm/rclone-csi/templates/rclone-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rclone-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{- range $key, $entry := .Values.configs -}}
+  {{- if $entry -}}
+  {{- $key | nindent 2 }}: "{{ $entry -}}"
+    {{- end }}
+  {{- end }}

--- a/deploy/helm/rclone-csi/values.yaml
+++ b/deploy/helm/rclone-csi/values.yaml
@@ -1,0 +1,39 @@
+# Default values for rclone-csi.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+configs:
+  remote: "s3"
+  #remotePath: "projectname"
+  #s3-provider: "Minio"
+  #s3-endpoint: "http://minio-release.default:9000"
+  #s3-access-key-id: "ACCESS_KEY_ID"
+  #s3-secret-access-key: "SECRET_ACCESS_KEY"
+
+storageClassName: rclone
+
+# Advanced settings
+# Changing these settings is not advised unless you know what you are doing
+pluginDirectory: /var/lib/kubelet/plugins/csi-rclone
+csiPlugin:
+  image: wunderio/csi-rclone:v1.2.3
+  args:
+    - "--nodeid=$(NODE_ID)"
+    - "--endpoint=$(CSI_ENDPOINT)"
+csiAttacher:
+  image: quay.io/k8scsi/csi-attacher:v1.1.1
+  args: 
+    - "--v=5"
+    - "--csi-address=$(ADDRESS)"
+csiClusterRegistrar:
+  image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+  args:
+    - "--v=5"
+    - "--pod-info-mount-version=\"v1\""
+    - "--csi-address=$(ADDRESS)"
+csiNodeRegistrar:
+  image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+  args:
+    - --v=5
+    - --csi-address=/plugin/csi.sock
+    - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-rclone/csi.sock


### PR DESCRIPTION
Hello,
First of all, thank you for all your work with this CSI. I am a researcher at JHU, part of the Galaxy Project (https://galaxyproject.org/ - https://en.wikipedia.org/wiki/Galaxy_(computational_biology)), and I stumbled upon your CSI while looking for a good way to run `rclone` in a K8S context.
While we are still looking at how the use of RClone fits into our deployment, I created a helm chart to facilitate deployment and accelerate debugging, and given that it is on your to-do list, I thought I'd PR-it back as well.
Other than externalizing images to the values file, the biggest change for the chart vs the manifests is the inclusion of the secret and PV/PVC volume pairs. In this context, a user can set their global configs and the specific PVs/PVCs with optional attributes through values.
I ran and tested this with the following command:

`helm install csi-rclone/deploy/helm/rclone-csi/ --namespace=rclone --set configs.remote="s3" --set configs.remotePath="[my-bucket]" --set configs.s3-region="us-east-2" --set configs.s3-provider="AWS" --set configs.s3-endpoint="https://s3.us-east-2.amazonaws.com" --set configs.s3-access-key-id="[my-id]" --set configs.s3-secret-access-key="[my-key]" --set configs.file-perms="0777" --set configs.links="true" --set configs.vfs-cache-mode="full" --set volumes.gxy.capacity=10Gi,volumes.gxy.claimNamespace=default` then successfully used the automatically create `gxy-pvc` as the claim for our chart's persistence, and it worked as expected!

I also wanted to make sure that using your CSI in our stack is okay with you, if we eventually decide to take this path forward, given that there is no license in the repository. Is this CSI meant for public use? We are an open-source academic project, and our work is generally under MIT license. If we are to adopt it, we'd use this CSI along our Galaxy chart: https://github.com/galaxyproject/galaxy-helm