### PR TITLE
Use rclone.conf - like configuration, in addition to cmd arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ stringData:
   s3-secret-access-key: "SECRET_ACCESS_KEY"
 ```
 
+Alternatively, you may specify rclone configuration file directly in the secret under `configData` field.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rclone-secret
+type: Opaque
+stringData:
+  remote: "my-s3"
+  remotePath: "projectname"
+  configData: |
+    [my-s3]
+    type = s3
+    provider = Minio
+    access_key_id = ACCESS_KEY_ID
+    secret_access_key = SECRET_ACCESS_KEY
+    endpoint = http://minio-release.default:9000
+```
+
 Deploy example secret
 > `kubectl apply -f example/kubernetes/rclone-secret-example.yaml --namespace kube-system`
 

--- a/example/kubernetes/rclone-secret-file-config.yaml
+++ b/example/kubernetes/rclone-secret-file-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rclone-secret
+  namespace: csi-rclone
+type: Opaque
+stringData:
+  remote: "my-s3"
+  remotePath: "projectname"
+  configData: |
+    [my-s3]
+    type = s3
+    provider = Minio
+    access_key_id = ACCESS_KEY_ID
+    secret_access_key = SECRET_ACCESS_KEY
+    endpoint = http://minio-release.default:9000


### PR DESCRIPTION
Hello,

I've added the support of classical `rclone.conf` TOML configuration. The configuration through command-line arguments has a major limitation -- not possible to use two different remotes of the same type. This PR aims to solve the issue.

I have tested the code, looks fine. It is backward-compatible with the existing cmdline-based config.

