### PR TITLE
Update deployment manifests to use `wunderio/csi-rclone:v3.0.1`

### DIFF
--- a/deploy/kubernetes/1.20/csi-controller-rclone.yaml
+++ b/deploy/kubernetes/1.20/csi-controller-rclone.yaml
@@ -47,7 +47,7 @@ spec:
             - name: socket-dir
               mountPath: /plugin
         - name: rclone
-          image: wunderio/csi-rclone:v3.0.0
+          image: wunderio/csi-rclone:v3.0.1
           args :
             - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/kubernetes/1.20/csi-nodeplugin-rclone.yaml
+++ b/deploy/kubernetes/1.20/csi-nodeplugin-rclone.yaml
@@ -44,7 +44,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: wunderio/csi-rclone:v3.0.0
+          image: wunderio/csi-rclone:v3.0.1
           args:
             - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"


### PR DESCRIPTION
This updates the deployment manifests to use `wunderio/csi-rclone:v3.0.1`.

I found that the image of the previous version, `v3.0.0` is not built for arm64. `v3.0.1` does support arm64.

I have manually tested this change in my k3s cluster with both arm64 and amd64 nodes.